### PR TITLE
Include the license file in the published crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,9 +7,9 @@ repository = "https://github.com/retis-org/btf-rs"
 homepage = "https://github.com/retis-org/btf-rs"
 readme = "README.md"
 keywords = ["bpf", "btf", "ebpf"]
-# Do not publish the tests and their data to save some space. Cargo files,
-# license & readme are always included.
-include = ["src/"]
+# Do not publish the tests and their data to save some space. Cargo files and
+# readme are always included.
+include = ["src/", "LICENSE"]
 edition = "2021"
 
 [badges]


### PR DESCRIPTION
Removing 'license-file' from Cargo.toml had a consequence: the LICENSE file is no longer published in the crate. Fix this.