### PR TITLE
Lookups by name aren't guaranteed to be unique

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ as its first argument.
 ```rust
 let btf = Btf::from_file("/sys/kernel/btf/vmlinux").unwrap();
 
-let func = match btf.resolve_type_by_name("kfree_skb_reason").unwrap() {
+let func = match btf.resolve_types_by_name("kfree_skb_reason").unwrap().pop().unwrap() {
 	Type::Func(func) => func,
 	_ => panic!("Resolved type is not a function"),
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,7 @@
 //!
 //! let btf = Btf::from_file("/sys/kernel/btf/vmlinux").unwrap();
 //!
-//! let func = match btf.resolve_type_by_name("kfree_skb_reason").unwrap() {
+//! let func = match btf.resolve_types_by_name("kfree_skb_reason").unwrap().pop().unwrap() {
 //!     Type::Func(func) => func,
 //!     _ => panic!("Resolved type is not a function"),
 //! };


### PR DESCRIPTION
In a base BTF or single split + base BTF, ids are guaranteed to be unique. But this is not the case for the strings, which can be used by more than one type.

Fix this by making a breaking API change and returning a vec instead of a single entry for "by name" lookups.