### PR TITLE
BTF collection implementation

### DIFF
--- a/src/btf.rs
+++ b/src/btf.rs
@@ -178,7 +178,7 @@ impl<'a> Iterator for TypeIter<'a> {
 
 /// Rust representation of BTF types. Each type then contains its own specific
 /// data and provides helpers to access it.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Type {
     Void,
     Int(Int),
@@ -264,7 +264,7 @@ pub trait BtfType {
 }
 
 /// Rust representation for BTF type `BTF_KIND_INT`.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Int {
     btf_type: cbtf::btf_type,
     btf_int: cbtf::btf_int,
@@ -306,7 +306,7 @@ impl BtfType for Int {
 }
 
 /// Rust representation for BTF type `BTF_KIND_PTR`.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Ptr {
     btf_type: cbtf::btf_type,
 }
@@ -324,7 +324,7 @@ impl BtfType for Ptr {
 }
 
 /// Rust representation for BTF type `BTF_KIND_ARRAY`.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Array {
     btf_type: cbtf::btf_type,
     btf_array: cbtf::btf_array,
@@ -355,7 +355,7 @@ impl BtfType for Array {
 }
 
 /// Rust representation for BTF type `BTF_KIND_STRUCT`.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Struct {
     btf_type: cbtf::btf_type,
     pub members: Vec<Member>,
@@ -395,7 +395,7 @@ impl BtfType for Struct {
 pub type Union = Struct;
 
 /// Represents a [`Struct`] member.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Member {
     kind_flag: u32,
     btf_member: cbtf::btf_member,
@@ -439,7 +439,7 @@ impl BtfType for Member {
 }
 
 /// Rust representation for BTF type `BTF_KIND_ENUM`.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Enum {
     btf_type: cbtf::btf_type,
     pub members: Vec<EnumMember>,
@@ -481,7 +481,7 @@ impl BtfType for Enum {
 }
 
 /// Represents an [`Enum`] member.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct EnumMember {
     btf_enum: cbtf::btf_enum,
 }
@@ -508,7 +508,7 @@ impl BtfType for EnumMember {
 }
 
 /// Rust representation for BTF type `BTF_KIND_FWD`.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Fwd {
     btf_type: cbtf::btf_type,
 }
@@ -536,7 +536,7 @@ impl BtfType for Fwd {
 }
 
 /// Rust representation for BTF type `BTF_KIND_TYPEDEF`.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Typedef {
     btf_type: cbtf::btf_type,
 }
@@ -561,7 +561,7 @@ impl BtfType for Typedef {
 pub type TypeTag = Typedef;
 
 /// Rust representation for BTF type `BTF_KIND_VOLATILE`.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Volatile {
     btf_type: cbtf::btf_type,
 }
@@ -585,7 +585,7 @@ pub type Const = Volatile;
 pub type Restrict = Volatile;
 
 /// Rust representation for BTF type `BTF_KIND_FUNC`.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Func {
     btf_type: cbtf::btf_type,
 }
@@ -619,7 +619,7 @@ impl BtfType for Func {
 }
 
 /// Rust representation for BTF type `BTF_KIND_FUNC_PROTO`.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct FuncProto {
     btf_type: cbtf::btf_type,
     pub parameters: Vec<Parameter>,
@@ -649,7 +649,7 @@ impl FuncProto {
 }
 
 /// Represents a [`FuncProto`] parameter.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Parameter {
     btf_param: cbtf::btf_param,
 }
@@ -680,7 +680,7 @@ impl BtfType for Parameter {
 }
 
 /// Rust representation for BTF type `BTF_KIND_VAR`.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Var {
     btf_type: cbtf::btf_type,
     btf_var: cbtf::btf_var,
@@ -718,7 +718,7 @@ impl BtfType for Var {
 }
 
 /// Rust representation for BTF type `BTF_KIND_DATASEC`.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Datasec {
     btf_type: cbtf::btf_type,
     pub variables: Vec<VarSecinfo>,
@@ -750,7 +750,7 @@ impl BtfType for Datasec {
 }
 
 /// Represents a [`Datasec`] variable.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct VarSecinfo {
     btf_var_secinfo: cbtf::btf_var_secinfo,
 }
@@ -781,7 +781,7 @@ impl BtfType for VarSecinfo {
 }
 
 /// Rust representation for BTF type `BTF_KIND_FLOAT`.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Float {
     btf_type: cbtf::btf_type,
 }
@@ -803,7 +803,7 @@ impl BtfType for Float {
 }
 
 /// Rust representation for BTF type `BTF_KIND_DECL_TAG`.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct DeclTag {
     btf_type: cbtf::btf_type,
     btf_decl_tag: cbtf::btf_decl_tag,
@@ -841,7 +841,7 @@ impl BtfType for DeclTag {
 }
 
 /// Rust representation for BTF type `BTF_KIND_ENUM64`.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Enum64 {
     btf_type: cbtf::btf_type,
     pub members: Vec<Enum64Member>,
@@ -883,7 +883,7 @@ impl BtfType for Enum64 {
 }
 
 /// Represents an [`Enum64`] member.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Enum64Member {
     btf_enum64: cbtf::btf_enum64,
 }

--- a/src/btf.rs
+++ b/src/btf.rs
@@ -79,7 +79,7 @@ impl Btf {
                 ids.append(&mut ids_base);
             }
         }
-        if let Ok(mut ids_obj) = self.obj.resolve_ids_by_name(name) {
+        if let Ok(mut ids_obj) = self.resolve_split_ids_by_name(name) {
             ids.append(&mut ids_obj);
         }
 
@@ -87,6 +87,12 @@ impl Btf {
             bail!("No id linked to name {name}");
         }
         Ok(ids)
+    }
+
+    /// Find a list of BTF ids using their name as a key, using the split BTF
+    /// definition only. For internal use only.
+    pub(crate) fn resolve_split_ids_by_name(&self, name: &str) -> Result<Vec<u32>> {
+        self.obj.resolve_ids_by_name(name)
     }
 
     /// Find a BTF type using its id as a key.
@@ -108,7 +114,7 @@ impl Btf {
                 types.append(&mut types_base);
             }
         }
-        if let Ok(mut types_obj) = self.obj.resolve_types_by_name(name) {
+        if let Ok(mut types_obj) = self.resolve_split_types_by_name(name) {
             types.append(&mut types_obj);
         }
 
@@ -118,6 +124,12 @@ impl Btf {
             bail!("No id linked to name {name}");
         }
         Ok(types)
+    }
+
+    /// Find a list of BTF types using their name as a key, using the split BTF
+    /// definition only. For internal use only.
+    pub(crate) fn resolve_split_types_by_name(&self, name: &str) -> Result<Vec<Type>> {
+        self.obj.resolve_types_by_name(name)
     }
 
     /// Resolve a name referenced by a Type which is defined in the current BTF

--- a/src/cbtf.rs
+++ b/src/cbtf.rs
@@ -77,7 +77,7 @@ impl btf_header {
     }
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[repr(C, packed)]
 pub(super) struct btf_type {
     pub(super) name_off: u32,
@@ -127,7 +127,7 @@ impl btf_type {
     }
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[repr(C, packed)]
 pub(super) struct btf_int {
     data: u32,
@@ -157,7 +157,7 @@ pub(super) const BTF_INT_SIGNED: u32 = 1 << 0;
 pub(super) const BTF_INT_CHAR: u32 = 1 << 1;
 pub(super) const BTF_INT_BOOL: u32 = 1 << 2;
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[repr(C, packed)]
 pub(super) struct btf_array {
     pub(super) r#type: u32,
@@ -178,7 +178,7 @@ impl btf_array {
     }
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[repr(C, packed)]
 pub(super) struct btf_member {
     pub(super) name_off: u32,
@@ -199,7 +199,7 @@ impl btf_member {
     }
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[repr(C, packed)]
 pub(super) struct btf_enum {
     pub(super) name_off: u32,
@@ -222,7 +222,7 @@ pub(super) const BTF_FUNC_STATIC: u32 = 0;
 pub(super) const BTF_FUNC_GLOBAL: u32 = 1;
 pub(super) const BTF_FUNC_EXTERN: u32 = 2;
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[repr(C, packed)]
 pub(super) struct btf_param {
     pub(super) name_off: u32,
@@ -241,7 +241,7 @@ impl btf_param {
     }
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[repr(C, packed)]
 pub(super) struct btf_var {
     pub(super) linkage: u32,
@@ -255,7 +255,7 @@ impl btf_var {
     }
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[repr(C, packed)]
 pub(super) struct btf_var_secinfo {
     pub(super) r#type: u32,
@@ -276,7 +276,7 @@ impl btf_var_secinfo {
     }
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[repr(C, packed)]
 pub(super) struct btf_decl_tag {
     pub(super) component_idx: i32,
@@ -293,7 +293,7 @@ impl btf_decl_tag {
     }
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[repr(C, packed)]
 pub(super) struct btf_enum64 {
     pub(super) name_off: u32,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,14 +89,22 @@
 //! and members, etc. can be retrieved. For all those see the [`Type`] and its
 //! associated structures documentation.
 //!
-//! Feature flags:
+//! ### Additional objects
+//!
+//! Additional objects built on top of the ones described here can be found in
+//! the [`utils`] sub-module. Those are aimed at easing BTF consumption in
+//! common cases.
+//!
+//! ### Feature flags
+//!
 //! - test_runtime: Use the system's runtime BTF files to perform extra
 //!   integration tests.
 
 pub mod btf;
+pub mod utils;
 
 mod cbtf;
 mod obj;
 
 #[doc(inline)]
-pub use crate::btf::*;
+pub use btf::*;

--- a/src/obj.rs
+++ b/src/obj.rs
@@ -157,7 +157,7 @@ impl BtfObj {
 
     /// Find a list of BTF ids using their name as a key.
     pub(super) fn resolve_ids_by_name(&self, name: &str) -> Result<Vec<u32>> {
-        match self.strings.get(&name.to_string()) {
+        match self.strings.get(name) {
             Some(ids) => Ok(ids.clone()),
             None => bail!("No id linked to name {name}"),
         }

--- a/src/utils/collection.rs
+++ b/src/utils/collection.rs
@@ -1,0 +1,223 @@
+//! ### Collection of one base BTF and its split BTF (e.g. full system)
+//!
+//! The [`BtfCollection`] object is provided to allow parsing a collection of
+//! one base BTF and 0 or more split BTFs. For example, it can be used to
+//! describe a kernel and all its modules.
+//!
+//! ```no_run
+//! use btf_rs::utils::collection::BtfCollection;
+//!
+//! let btfc_sys = BtfCollection::from_dir("/sys/kernel/btf", "vmlinux").unwrap();
+//!
+//! let mut btfc = BtfCollection::from_file("/sys/kernel/btf/vmlinux").unwrap();
+//! btfc.add_split_btf_from_file("/sys/kernel/btf/openvswitch").unwrap();
+//! btfc.add_split_btf_from_file("/sys/kernel/btf/nf_tables").unwrap();
+//! ```
+//!
+//! [`BtfCollection`] also supports being constructed from byte slices.
+//!
+//! Due to how split BTF are constructed, [`BtfCollection`] does not provide
+//! helpers returning a single match but instead return lists of matches
+//! containing a [`NamedBtf`] reference. This new [`NamedBtf`] type embed
+//! both the [`crate::Btf`] representation and a name to uniquely identify it.
+//! Subsequent lookups for the type or id returned must be done using the
+//! [`crate::Btf`] representation returned in the [`NamedBtf`] reference. See
+//! [`BtfCollection::resolve_ids_by_name`] and
+//! [`BtfCollection::resolve_types_by_name`].
+use std::{fs, ops::Deref, path::Path};
+
+use anyhow::{bail, Result};
+
+use crate::{Btf, Type};
+
+/// BtfCollection provides a full system BTF view, by combining a base BTF
+/// information with multiple split BTFs.
+///
+/// Provides resolve by name helpers (looking up by id cannot work as ids are
+/// reused in different split BTF), which behave similarly to the ones in `Btf`
+/// but returning an additional named reference to the `Btf` object where the
+/// resolution was done. This is important as further lookups for the returned
+/// value must be done using the `Btf` object returned.
+///
+/// The base BTF lookups are prioritized over the split BTF ones.
+pub struct BtfCollection {
+    /// Main BTF object for the kernel.
+    base: NamedBtf,
+    /// Split BTF information.
+    split: Vec<NamedBtf>,
+}
+
+/// Struct embedding a Btf object alongside a name to uniquely identify it. Used
+/// to manipulate Btf objects when there could be multiple matches.
+pub struct NamedBtf {
+    /// Name of the BtfObject.
+    pub name: String,
+    /// The Btf object.
+    pub btf: Btf,
+}
+
+/// Let dereference NamedBtf into Btf directly for ease of use.
+impl Deref for NamedBtf {
+    type Target = Btf;
+
+    fn deref(&self) -> &Self::Target {
+        &self.btf
+    }
+}
+
+impl BtfCollection {
+    /// Construct a BtfCollection object from a base BTF file only.
+    pub fn from_file<P: AsRef<Path>>(path: P) -> Result<BtfCollection> {
+        Ok(BtfCollection {
+            base: NamedBtf {
+                name: Self::file_name(path.as_ref())?,
+                btf: Btf::from_file(path)?,
+            },
+            split: Vec::new(),
+        })
+    }
+
+    /// Construct a BtfCollection object from a base BTF file only.
+    pub fn from_bytes(name: &str, bytes: &[u8]) -> Result<BtfCollection> {
+        Ok(BtfCollection {
+            base: NamedBtf {
+                name: name.to_string(),
+                btf: Btf::from_bytes(bytes)?,
+            },
+            split: Vec::new(),
+        })
+    }
+
+    /// Add a split BTF in the current BtfCollection representation, reading a file.
+    pub fn add_split_btf_from_file<P: AsRef<Path>>(&mut self, path: P) -> Result<&mut Self> {
+        let name = Self::file_name(path.as_ref())?;
+
+        if self.split.iter().any(|m| m.name == name) {
+            bail!("Split BTF with name {name} already present");
+        }
+
+        self.split.push(NamedBtf {
+            name,
+            btf: Btf::from_split_file(path, &self.base.btf)?,
+        });
+        Ok(self)
+    }
+
+    /// Add a split BTF in the current BtfCollection representation, reading a byte slice.
+    pub fn add_split_btf_from_bytes(&mut self, name: &str, bytes: &[u8]) -> Result<&mut Self> {
+        let name = name.to_string();
+        if self.split.iter().any(|m| m.name == name) {
+            bail!("Split BTF with name {name} already present");
+        }
+
+        self.split.push(NamedBtf {
+            name,
+            btf: Btf::from_split_bytes(bytes, &self.base.btf)?,
+        });
+        Ok(self)
+    }
+
+    /// Parse BTF objects stored in a directory and construct a BtfCollection
+    /// object, given a path to the directory and the filename of the base BTF file.
+    /// This is helpful for parsing /sys/kernel/btf for example.
+    pub fn from_dir<P: AsRef<Path>>(dir: P, base: &str) -> Result<BtfCollection> {
+        // First parse the base BTF information.
+        let mut sys_btf = BtfCollection::from_file(format!("{}/{base}", dir.as_ref().display()))?;
+
+        // Then loop over all split BTF files and parse them.
+        for file in fs::read_dir(dir.as_ref())? {
+            match file {
+                Ok(file) => {
+                    if file.file_name() == base {
+                        continue;
+                    }
+                    if let Ok(ft) = file.file_type() {
+                        if !ft.is_dir() {
+                            sys_btf.add_split_btf_from_file(file.path())?;
+                        }
+                    }
+                }
+                Err(e) => bail!("Error reading file from {}: {e}", dir.as_ref().display()),
+            }
+        }
+
+        Ok(sys_btf)
+    }
+
+    /// Get a reference to a `NamedBtf` given a module name. This `NamedBtf` can
+    /// then be used to perform scoped lookups.
+    pub fn get_named_btf(&self, name: &str) -> Option<&NamedBtf> {
+        self.split.iter().find(|m| m.name == name)
+    }
+
+    /// Find a list of BTF ids using their name as a key. Matching ids can be
+    /// found in multiple underlying BTF, thus this function returns a list of
+    /// tuples containing each a reference to `NamedBtf` (representing the BTF
+    /// where a match was found) and the id. Further lookups must be done using
+    /// the `Btf` object contained in the linked `NamedBtf` one.
+    pub fn resolve_ids_by_name(&self, name: &str) -> Result<Vec<(&NamedBtf, u32)>> {
+        let mut ids = Vec::new();
+
+        let mut base_ids = match self.base.btf.resolve_ids_by_name(name) {
+            Ok(base_ids) => base_ids,
+            _ => Vec::new(), // Id not found in base.
+        };
+
+        for split in self.split.iter() {
+            if let Ok(mut mod_ids) = split.btf.resolve_split_ids_by_name(name) {
+                mod_ids.drain(..).for_each(|i| ids.push((split, i)));
+            }
+        }
+
+        // Now add ids found in the base BTF.
+        base_ids.drain(..).for_each(|i| ids.push((&self.base, i)));
+
+        if ids.is_empty() {
+            bail!("No id linked to name {name}");
+        }
+
+        Ok(ids)
+    }
+
+    /// Find a list of BTF types using their name as a key. Matching types can
+    /// be found in multiple underlying BTF, thus this function returns a list
+    /// of tuples containing each a reference to `NamedBtf` (representing the
+    /// BTF where a match was found) and the type. Further lookups must be done
+    /// using the `Btf` object contained in the linked `NamedBtf` one.
+    pub fn resolve_types_by_name(&self, name: &str) -> Result<Vec<(&NamedBtf, Type)>> {
+        let mut types = Vec::new();
+
+        let mut base_types = match self.base.btf.resolve_types_by_name(name) {
+            Ok(base_types) => base_types,
+            _ => Vec::new(), // Id not found in base.
+        };
+
+        for split in self.split.iter() {
+            if let Ok(mut mod_types) = split.btf.resolve_split_types_by_name(name) {
+                mod_types.drain(..).for_each(|t| types.push((split, t)));
+            }
+        }
+
+        // Now add types found in the base BTF.
+        base_types
+            .drain(..)
+            .for_each(|t| types.push((&self.base, t)));
+
+        if types.is_empty() {
+            bail!("No type linked to name {name}");
+        }
+
+        Ok(types)
+    }
+
+    // Internal helper to extract a file name as a String from a Path.
+    fn file_name(path: &Path) -> Result<String> {
+        Ok(match path.file_name() {
+            Some(name) => match name.to_str() {
+                Some(s) => s.to_string(),
+                None => bail!("Invalid file name {:?}", name),
+            },
+            None => bail!("Could not get file name from path {}", path.display()),
+        })
+    }
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,0 +1,4 @@
+//! Utils built on top of the `btf_rs` library to ease the development in common
+//! use cases.
+
+pub mod collection;


### PR DESCRIPTION
Adding a sub-module `utils` to help in common cases. At first, adding a `BtfCollection` to support parsing a base BTF and all its split-BTF (e.g. representing a full system).