### PR TITLE
return type id from btf_array instead of btf_type

### DIFF
--- a/src/btf.rs
+++ b/src/btf.rs
@@ -284,7 +284,7 @@ impl Array {
 
 impl BtfType for Array {
     fn get_type_id(&self) -> Result<u32> {
-        Ok(self.btf_type.r#type())
+        Ok(self.btf_array.r#type)
     }
 }
 


### PR DESCRIPTION
Found while resolving chained type for arrays. More info in the commit message.