### PR TITLE
btf: fwd: add accessors for `kind_flag`

### DIFF
--- a/src/btf.rs
+++ b/src/btf.rs
@@ -517,6 +517,16 @@ impl Fwd {
     pub(super) fn new(btf_type: cbtf::btf_type) -> Fwd {
         Fwd { btf_type }
     }
+
+    /// Tests if the forward declaration is for a struct type.
+    pub fn is_struct(&self) -> bool {
+        self.btf_type.kind_flag() == 0
+    }
+
+    /// Tests if the forward declaration is for a union type.
+    pub fn is_union(&self) -> bool {
+        self.btf_type.kind_flag() == 1
+    }
 }
 
 impl BtfType for Fwd {


### PR DESCRIPTION
Add helpers to access the `kind_flag` of forward declarations. On `BTF_KIND_FWD` the `kind_flag` is 0 for structs and 1 for unions, c.f., https://www.kernel.org/doc/html/latest/bpf/btf.html?highlight=btf#btf-kind-fwd.