### PR TITLE
Cargo.toml: fix SPDX

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "btf-rs"
 version = "1.1.0"
-license = "LGPL-2.0-or-later"
+license = "LGPL-2.1-or-later"
 description = "Library for the BPF type format (BTF)."
 repository = "https://github.com/retis-org/btf-rs"
 homepage = "https://github.com/retis-org/btf-rs"


### PR DESCRIPTION
SPDX says LGPL-2.0-or-later while the license really is LGPL-2.1-or-later.