### PR TITLE
Use our own error type (move from anyhow to thiserror)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,10 @@ edition = "2021"
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-anyhow = "1.0"
 byteorder = "1.5"
 elf = { version = "0.7", optional = true }
 regex = { version = "1.10", optional = true }
+thiserror = "2.0"
 
 [dev-dependencies]
 test-case = "3.2"

--- a/src/btf.rs
+++ b/src/btf.rs
@@ -175,7 +175,7 @@ impl Btf {
     /// This helper returns an iterator that allow to resolve a Type
     /// referenced in another one all the way down to the chain.
     /// The helper makes use of `Btf::resolve_chained_type()`.
-    pub fn type_iter<'a, T: BtfType + ?Sized>(&'a self, r#type: &'a T) -> TypeIter {
+    pub fn type_iter<T: BtfType + ?Sized>(&self, r#type: &T) -> TypeIter {
         TypeIter {
             btf: self,
             r#type: self.resolve_chained_type(r#type).ok(),
@@ -190,7 +190,7 @@ pub struct TypeIter<'a> {
 }
 
 /// Iterator for `Btf::TypeIter`.
-impl<'a> Iterator for TypeIter<'a> {
+impl Iterator for TypeIter<'_> {
     type Item = Type;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -932,7 +932,7 @@ impl Enum64Member {
     }
 
     pub fn val(&self) -> u64 {
-        (self.btf_enum64.val_hi32 as u64) << 32 | self.btf_enum64.val_lo32 as u64
+        ((self.btf_enum64.val_hi32 as u64) << 32) | self.btf_enum64.val_lo32 as u64
     }
 }
 

--- a/src/cbtf.rs
+++ b/src/cbtf.rs
@@ -7,8 +7,9 @@
 
 use std::io::Read;
 
-use anyhow::{bail, Result};
 use byteorder::{BigEndian, LittleEndian, ReadBytesExt};
+
+use crate::{Error, Result};
 
 pub(super) enum Endianness {
     Little,
@@ -16,21 +17,21 @@ pub(super) enum Endianness {
 }
 
 impl Endianness {
-    fn u16_from_reader<R: Read>(&self, reader: &mut R) -> Result<u16, std::io::Error> {
+    fn u16_from_reader<R: Read>(&self, reader: &mut R) -> std::result::Result<u16, std::io::Error> {
         match &self {
             Endianness::Little => reader.read_u16::<LittleEndian>(),
             Endianness::Big => reader.read_u16::<BigEndian>(),
         }
     }
 
-    fn u32_from_reader<R: Read>(&self, reader: &mut R) -> Result<u32, std::io::Error> {
+    fn u32_from_reader<R: Read>(&self, reader: &mut R) -> std::result::Result<u32, std::io::Error> {
         match &self {
             Endianness::Little => reader.read_u32::<LittleEndian>(),
             Endianness::Big => reader.read_u32::<BigEndian>(),
         }
     }
 
-    fn i32_from_reader<R: Read>(&self, reader: &mut R) -> Result<i32, std::io::Error> {
+    fn i32_from_reader<R: Read>(&self, reader: &mut R) -> std::result::Result<i32, std::io::Error> {
         match &self {
             Endianness::Little => reader.read_i32::<LittleEndian>(),
             Endianness::Big => reader.read_i32::<BigEndian>(),
@@ -58,7 +59,7 @@ impl btf_header {
         let endianness = match magic {
             0xeB9F => Endianness::Little,
             0x9FeB => Endianness::Big,
-            magic => bail!("Invalid BTF magic: {:#x}", magic),
+            magic => return Err(Error::Format(format!("Invalid BTF magic: {:#x}", magic))),
         };
 
         Ok((

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,24 @@
+use thiserror;
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+#[non_exhaustive]
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    /// I/O error, from `std::io::Error`.
+    #[error("i/o error: {0}")]
+    IO(#[from] std::io::Error),
+    /// Format error: invalid input file or directory, wrongly formatted file,
+    /// invalid BTF format.
+    #[error("{0}")]
+    Format(String),
+    /// Operation not supported.
+    #[error("operation not supported: {0}")]
+    OpNotSupp(String),
+    /// Invalid type.
+    #[error("no type with id {0}")]
+    InvalidType(u32),
+    /// Invalid string reference.
+    #[error("no string at offset {0}")]
+    InvalidString(u32),
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,6 +109,7 @@
 //!   integration tests.
 
 pub mod btf;
+pub mod error;
 pub mod utils;
 
 mod cbtf;
@@ -116,3 +117,4 @@ mod obj;
 
 #[doc(inline)]
 pub use btf::*;
+pub use error::*;

--- a/src/utils/elf.rs
+++ b/src/utils/elf.rs
@@ -3,29 +3,38 @@ use std::{
     path::Path,
 };
 
-use anyhow::{anyhow, bail, Result};
 use elf::{endian::AnyEndian, ElfStream};
 
-use crate::utils::collection::BtfCollection;
+use crate::{utils::collection::BtfCollection, Error, Result};
 
 /// Extract raw BTF data from the .BTF elf section of the given file. Output can
 /// be used to fed `from_bytes` constructors in this library.
 pub fn extract_btf_from_file<P: AsRef<Path>>(path: P) -> Result<Vec<u8>> {
-    let file = File::open(&path)
-        .map_err(|e| anyhow!("Could not open {}: {e}", path.as_ref().display()))?;
-    let mut elf = ElfStream::<AnyEndian, _>::open_stream(file)?;
+    let file = File::open(&path)?;
+    let mut elf = ElfStream::<AnyEndian, _>::open_stream(file)
+        .map_err(|e| Error::Format(format!("Could not parse ELF file: {e}")))?;
 
-    let btf_hdr = match elf.section_header_by_name(".BTF")? {
+    let btf_hdr = match elf
+        .section_header_by_name(".BTF")
+        .map_err(|e| Error::Format(format!("Could not get ELF section header for .BTF: {e}")))?
+    {
         Some(hdr) => *hdr,
-        None => bail!("No BTF section in {}", path.as_ref().display()),
+        None => {
+            return Err(Error::Format(format!(
+                "No BTF section in {}",
+                path.as_ref().display()
+            )))
+        }
     };
 
-    let (btf, chdr) = elf.section_data(&btf_hdr)?;
+    let (btf, chdr) = elf
+        .section_data(&btf_hdr)
+        .map_err(|e| Error::Format(format!("Could not get ELF section data: {e}")))?;
     if chdr.is_some() {
-        bail!(
+        return Err(Error::Format(format!(
             "Compressed BTF sections are not supported ({})",
             path.as_ref().display()
-        );
+        )));
     }
 
     Ok(btf.to_vec())
@@ -38,10 +47,10 @@ pub fn extract_btf_from_file<P: AsRef<Path>>(path: P) -> Result<Vec<u8>> {
 pub fn collection_from_kernel_dir<P: AsRef<Path>>(path: P) -> Result<BtfCollection> {
     let path = path.as_ref();
     if !path.is_dir() {
-        bail!(
+        return Err(Error::Format(format!(
             "Can't initialize a BTF collection from {}: not a directory",
             path.display()
-        );
+        )));
     }
 
     // Find the base BTF file and initialize the collection.
@@ -54,9 +63,9 @@ pub fn collection_from_kernel_dir<P: AsRef<Path>>(path: P) -> Result<BtfCollecti
             let path = entry?.path();
             let filename = path
                 .file_name()
-                .ok_or_else(|| anyhow!("Could not get module file name"))?
+                .ok_or_else(|| Error::Format("Could not get module file name".to_string()))?
                 .to_str()
-                .ok_or_else(|| anyhow!("Could not convert module name to str"))?;
+                .ok_or_else(|| Error::Format("Could not convert module name to str".to_string()))?;
 
             if path.is_dir() {
                 visit_dir(path, collection)?;
@@ -65,7 +74,7 @@ pub fn collection_from_kernel_dir<P: AsRef<Path>>(path: P) -> Result<BtfCollecti
                     match filename.split_once('.') {
                         Some((name, _)) => name,
                         // Should not happen as we already filtered on extensions.
-                        None => bail!("Invalid module file name"),
+                        None => return Err(Error::Format("Invalid module file name".to_string())),
                     },
                     &extract_btf_from_file(&path)?,
                 )?;


### PR DESCRIPTION
As a library we should let the user control the behavior upon error.

A question is whether or not to split the `Error::Format` variant; I chose to keep it quite versatile because I did not see what kind of different actions one could take but feel free to disagree :)