### PR TITLE
Expose BTF sections and allow iterating over types

### DIFF
--- a/btf-rs/Cargo.toml
+++ b/btf-rs/Cargo.toml
@@ -20,6 +20,7 @@ btf-rs-derive = { path = "../btf-rs-derive", version = "1.1" }
 byteorder = "1.5"
 bzip2 = { version = "0.6", optional = true }
 elf = { version = "0.8", optional = true }
+fallible-iterator = "0.3"
 flate2 = { version = "1.1", optional = true }
 liblzma = { version = "0.4", optional = true }
 memmap2 = "0.9"

--- a/btf-rs/src/btf.rs
+++ b/btf-rs/src/btf.rs
@@ -11,9 +11,9 @@ use std::{
 
 use memmap2::MmapOptions;
 
-use crate::{cbtf, obj::BtfObj, Error, Result};
+use crate::{cbtf, section::BtfSection, Error, Result};
 
-/// Backend used by the `Btf` object to store and access the underlying BTF
+/// Backend used by the [`Btf`] object to store and access the underlying BTF
 /// information.
 #[non_exhaustive]
 pub enum Backend {
@@ -27,16 +27,16 @@ pub enum Backend {
     Mmap,
 }
 
-/// Main representation of a parsed BTF object. Provides helpers to resolve
-/// types and their associated names.
+/// Main representation of parsed BTF data. Provides helpers to resolve types
+/// and their associated names.
 pub struct Btf {
-    obj: Arc<BtfObj>,
-    base: Option<Arc<BtfObj>>,
+    obj: Arc<BtfSection>,
+    base: Option<Arc<BtfSection>>,
 }
 
 impl Btf {
-    /// Parse a stand-alone BTF object file and construct a Rust representation
-    /// for later use. By default [`Backend::Cache`] is used.
+    /// Parse a stand-alone BTF section from a file and construct a Rust
+    /// representation for later use. By default [`Backend::Cache`] is used.
     ///
     /// Trying to open split BTF files using this function will fail. For split
     /// BTF files use [`Btf::from_split_file`].
@@ -51,9 +51,9 @@ impl Btf {
         Ok(Btf {
             obj: Arc::new(match backend {
                 Backend::Cache => {
-                    BtfObj::from_reader(&mut BufReader::new(File::open(path)?), None)?
+                    BtfSection::from_reader(&mut BufReader::new(File::open(path)?), None)?
                 }
-                Backend::Mmap => BtfObj::from_mmap(
+                Backend::Mmap => BtfSection::from_mmap(
                     unsafe { MmapOptions::new().map_copy_read_only(&File::open(path)?)? },
                     None,
                 )?,
@@ -62,15 +62,16 @@ impl Btf {
         })
     }
 
-    /// Parse a split BTF object file and construct a Rust representation for later
-    /// use. A base Btf object must be provided.
+    /// Parse a split BTF section from a file and construct a Rust
+    /// representation for later use. A base [`Btf`] containing the base section
+    /// must be provided.
     pub fn from_split_file<P: AsRef<Path>>(path: P, base: &Btf) -> Result<Btf> {
         if base.base.is_some() {
             return Err(Error::OpNotSupp("Provided base is a split BTF".to_string()));
         }
 
         Ok(Btf {
-            obj: Arc::new(BtfObj::from_reader(
+            obj: Arc::new(BtfSection::from_reader(
                 &mut BufReader::new(File::open(path)?),
                 Some(base.obj.clone()),
             )?),
@@ -82,7 +83,7 @@ impl Btf {
     /// slice.
     pub fn from_bytes(bytes: &[u8]) -> Result<Btf> {
         Ok(Btf {
-            obj: Arc::new(BtfObj::from_reader(&mut Cursor::new(bytes), None)?),
+            obj: Arc::new(BtfSection::from_reader(&mut Cursor::new(bytes), None)?),
             base: None,
         })
     }
@@ -96,12 +97,30 @@ impl Btf {
 
         let base = base.obj.clone();
         Ok(Btf {
-            obj: Arc::new(BtfObj::from_reader(
+            obj: Arc::new(BtfSection::from_reader(
                 &mut Cursor::new(bytes),
                 Some(base.clone()),
             )?),
             base: Some(base),
         })
+    }
+
+    /// Returns a reference the base BTF section. For non-split `Btf` the base
+    /// BTF section holds the full BTF representation. Base BTF sections are
+    /// standalone representations (no reference to external BTF sections).
+    pub fn base(&self) -> &BtfSection {
+        match &self.base {
+            Some(base) => base,
+            None => &self.obj,
+        }
+    }
+
+    /// Returns a reference to the split BTF section, if any. A split BTF
+    /// section is not a standalone representation (it uses references to a base
+    /// BTF section).
+    pub fn split(&self) -> Option<&BtfSection> {
+        self.base.as_ref()?;
+        Some(&self.obj)
     }
 
     /// Find a list of BTF ids using their name as a key.
@@ -199,8 +218,8 @@ impl Btf {
         self.obj.resolve_types_by_regex(re)
     }
 
-    /// Resolve a name referenced by a Type which is defined in the current BTF
-    /// object.
+    /// Resolve a name referenced by a Type which is defined in the current
+    /// [`Btf`] object.
     pub fn resolve_name(&self, r#type: &dyn BtfType) -> Result<String> {
         match &self.base {
             Some(base) => base

--- a/btf-rs/src/btf.rs
+++ b/btf-rs/src/btf.rs
@@ -216,22 +216,21 @@ impl Btf {
     /// This helper returns an iterator that allow to resolve a Type
     /// referenced in another one all the way down to the chain.
     /// The helper makes use of [`Btf::resolve_chained_type`].
-    pub fn type_iter<T: BtfType + ?Sized>(&self, r#type: &T) -> TypeIter<'_> {
-        TypeIter {
+    pub fn chained_type_iter<T: BtfType + ?Sized>(&self, r#type: &T) -> ChainedTypeIter<'_> {
+        ChainedTypeIter {
             btf: self,
             r#type: self.resolve_chained_type(r#type).ok(),
         }
     }
 }
 
-/// Iterator type returned by [`Btf::type_iter`].
-pub struct TypeIter<'a> {
+/// Iterator over chained types (types referencing other types in a chain).
+pub struct ChainedTypeIter<'a> {
     btf: &'a Btf,
     r#type: Option<Type>,
 }
 
-/// Iterator for [`TypeIter`].
-impl Iterator for TypeIter<'_> {
+impl Iterator for ChainedTypeIter<'_> {
     type Item = Type;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/btf-rs/src/btf.rs
+++ b/btf-rs/src/btf.rs
@@ -124,10 +124,9 @@ impl Btf {
         Some(&self.obj)
     }
 
-    /// Find a list of BTF ids using their name as a key.
+    /// Find a list of BTF ids with a given name.
     ///
-    /// Using an empty name (`""`) resolves anonymous types (for BTF kinds
-    /// allowing it).
+    /// Using an empty name (`""`) resolves anonymous ids.
     pub fn resolve_ids_by_name(&self, name: &str) -> Result<Vec<u32>> {
         let mut ids = self.obj.resolve_ids_by_name(name)?;
 
@@ -140,8 +139,8 @@ impl Btf {
 
     /// Find a list of BTF ids whose names match a regex.
     ///
-    /// Using an empty name (`""`) resolves anonymous types (for BTF kinds
-    /// allowing it).
+    /// If the regex matches the empty name (`""`), e.g. `"^$"`, the result will
+    /// contain anonymous ids.
     #[cfg(feature = "regex")]
     pub fn resolve_ids_by_regex(&self, re: &regex::Regex) -> Result<Vec<u32>> {
         let mut ids = self.obj.resolve_ids_by_regex(re)?;
@@ -153,7 +152,7 @@ impl Btf {
         Ok(ids)
     }
 
-    /// Find a BTF type using its id as a key.
+    /// Find a BTF type with a given id.
     pub fn resolve_type_by_id(&self, id: u32) -> Result<Type> {
         if let Some(base) = &self.base {
             if let Ok(r#type) = base.resolve_type_by_id(id) {
@@ -164,10 +163,9 @@ impl Btf {
         self.obj.resolve_type_by_id(id)
     }
 
-    /// Find a list of BTF types using their name as a key.
+    /// Find a list of BTF types with a given name.
     ///
-    /// Using an empty name (`""`) resolves anonymous types (for BTF kinds
-    /// allowing it).
+    /// Using an empty name (`""`) resolves anonymous types.
     pub fn resolve_types_by_name(&self, name: &str) -> Result<Vec<Type>> {
         let mut types = self.obj.resolve_types_by_name(name)?;
 
@@ -178,10 +176,10 @@ impl Btf {
         Ok(types)
     }
 
-    /// Find a list of BTF types using a regex describing their name as a key.
+    /// Find a list of BTF types whose names match a regex.
     ///
-    /// Using an empty name (`""`) resolves anonymous types (for BTF kinds
-    /// allowing it).
+    /// If the regex matches the empty name (`""`), e.g. `"^$"`, the result will
+    /// contain anonymous types.
     #[cfg(feature = "regex")]
     pub fn resolve_types_by_regex(&self, re: &regex::Regex) -> Result<Vec<Type>> {
         let mut types = self.obj.resolve_types_by_regex(re)?;

--- a/btf-rs/src/btf.rs
+++ b/btf-rs/src/btf.rs
@@ -128,7 +128,7 @@ impl Btf {
     /// Using an empty name (`""`) resolves anonymous types (for BTF kinds
     /// allowing it).
     pub fn resolve_ids_by_name(&self, name: &str) -> Result<Vec<u32>> {
-        let mut ids = self.resolve_split_ids_by_name(name)?;
+        let mut ids = self.obj.resolve_ids_by_name(name)?;
 
         if let Some(base) = &self.base {
             ids.append(&mut base.resolve_ids_by_name(name)?);
@@ -137,32 +137,19 @@ impl Btf {
         Ok(ids)
     }
 
-    // Find a list of BTF ids using their name as a key, using the split BTF
-    // definition only. For internal use only.
-    pub(crate) fn resolve_split_ids_by_name(&self, name: &str) -> Result<Vec<u32>> {
-        self.obj.resolve_ids_by_name(name)
-    }
-
     /// Find a list of BTF ids whose names match a regex.
     ///
     /// Using an empty name (`""`) resolves anonymous types (for BTF kinds
     /// allowing it).
     #[cfg(feature = "regex")]
     pub fn resolve_ids_by_regex(&self, re: &regex::Regex) -> Result<Vec<u32>> {
-        let mut ids = self.resolve_split_ids_by_regex(re)?;
+        let mut ids = self.obj.resolve_ids_by_regex(re)?;
 
         if let Some(base) = &self.base {
             ids.append(&mut base.resolve_ids_by_regex(re)?);
         }
 
         Ok(ids)
-    }
-
-    // Find a list of BTF ids whose names match a regex, using the split BTF
-    // definition only. For internal use only.
-    #[cfg(feature = "regex")]
-    pub(crate) fn resolve_split_ids_by_regex(&self, re: &regex::Regex) -> Result<Vec<u32>> {
-        self.obj.resolve_ids_by_regex(re)
     }
 
     /// Find a BTF type using its id as a key.
@@ -181,7 +168,7 @@ impl Btf {
     /// Using an empty name (`""`) resolves anonymous types (for BTF kinds
     /// allowing it).
     pub fn resolve_types_by_name(&self, name: &str) -> Result<Vec<Type>> {
-        let mut types = self.resolve_split_types_by_name(name)?;
+        let mut types = self.obj.resolve_types_by_name(name)?;
 
         if let Some(base) = &self.base {
             types.append(&mut base.resolve_types_by_name(name)?);
@@ -190,32 +177,19 @@ impl Btf {
         Ok(types)
     }
 
-    // Find a list of BTF types using their name as a key, using the split BTF
-    // definition only. For internal use only.
-    pub(crate) fn resolve_split_types_by_name(&self, name: &str) -> Result<Vec<Type>> {
-        self.obj.resolve_types_by_name(name)
-    }
-
     /// Find a list of BTF types using a regex describing their name as a key.
     ///
     /// Using an empty name (`""`) resolves anonymous types (for BTF kinds
     /// allowing it).
     #[cfg(feature = "regex")]
     pub fn resolve_types_by_regex(&self, re: &regex::Regex) -> Result<Vec<Type>> {
-        let mut types = self.resolve_split_types_by_regex(re)?;
+        let mut types = self.obj.resolve_types_by_regex(re)?;
 
         if let Some(base) = &self.base {
             types.append(&mut base.resolve_types_by_regex(re)?);
         }
 
         Ok(types)
-    }
-
-    // Find a list of BTF types using a regex describing their name as a key,
-    // using the split BTF definition only. For internal use only.
-    #[cfg(feature = "regex")]
-    pub(crate) fn resolve_split_types_by_regex(&self, re: &regex::Regex) -> Result<Vec<Type>> {
-        self.obj.resolve_types_by_regex(re)
     }
 
     /// Resolve a name referenced by a Type which is defined in the current

--- a/btf-rs/src/btf.rs
+++ b/btf-rs/src/btf.rs
@@ -9,6 +9,7 @@ use std::{
     sync::Arc,
 };
 
+use fallible_iterator::FallibleIterator;
 use memmap2::MmapOptions;
 
 use crate::{cbtf, section::BtfSection, Error, Result};
@@ -203,6 +204,11 @@ impl Btf {
         }
     }
 
+    /// Return an iterator over all types defined in the current BTF object.
+    pub fn type_iter(&self) -> TypeIter<'_> {
+        TypeIter::new(&self.obj, self.base.as_ref().map(|s| s.as_ref()))
+    }
+
     /// Types can have a reference to another one, e.g. `Ptr -> Int`. This
     /// helper resolve a Type referenced in an other one. It is the main helper
     /// to traverse the Type tree.
@@ -221,6 +227,49 @@ impl Btf {
             btf: self,
             r#type: self.resolve_chained_type(r#type).ok(),
         }
+    }
+}
+
+/// Iterator over BTF types.
+pub struct TypeIter<'a> {
+    pub(crate) section: &'a BtfSection,
+    pub(crate) next_section: Option<&'a BtfSection>,
+    cursor: u32,
+    end: u32,
+}
+
+impl<'a> TypeIter<'a> {
+    pub(crate) fn new(section: &'a BtfSection, next_section: Option<&'a BtfSection>) -> Self {
+        let (start, end) = section.type_id_range();
+
+        TypeIter {
+            section,
+            next_section,
+            cursor: start,
+            end,
+        }
+    }
+}
+
+impl FallibleIterator for TypeIter<'_> {
+    type Item = Type;
+    type Error = Error;
+
+    fn next(&mut self) -> Result<Option<Self::Item>> {
+        // Go to the next section if needed.
+        if self.cursor > self.end {
+            self.section = match self.next_section.take() {
+                Some(section) => section,
+                None => return Ok(None),
+            };
+
+            (self.cursor, self.end) = self.section.type_id_range();
+        }
+
+        let r#type = self.section.resolve_type_by_id(self.cursor)?;
+        self.cursor += 1;
+
+        Ok(Some(r#type))
     }
 }
 

--- a/btf-rs/src/lib.rs
+++ b/btf-rs/src/lib.rs
@@ -148,7 +148,7 @@
 // - `cbtf` operates at the BTF metadata level. It allows to handle the format
 //   and provides an API enforcing the format rules. It strictly follows the
 //   format definition.
-// - `obj` handles our representation of the BTF data and allow converting
+// - `section` handles our representation of the BTF data and allow converting
 //   `cbtf` representation into `btf` ones.
 // - `btf` provides our representation of the BTF data in Rust and a unified API
 //   on top of the BTF metadata representations. Additional logic is allowed,
@@ -161,8 +161,9 @@ pub mod error;
 pub mod utils;
 
 mod cbtf;
-mod obj;
+mod section;
 
 #[doc(inline)]
 pub use btf::*;
 pub use error::*;
+pub use section::BtfSection;

--- a/btf-rs/src/section.rs
+++ b/btf-rs/src/section.rs
@@ -92,6 +92,11 @@ impl BtfSection {
         (start, end)
     }
 
+    /// Return an iterator over all types defined in the current BTF section.
+    pub fn type_iter(&self) -> TypeIter<'_> {
+        TypeIter::new(self, None)
+    }
+
     // Resolve a name referenced by a Type which is defined in the current BTF
     // section.
     pub(super) fn resolve_name(&self, r#type: &dyn BtfType) -> Result<String> {

--- a/btf-rs/src/section.rs
+++ b/btf-rs/src/section.rs
@@ -31,32 +31,30 @@ impl BtfSection {
         Ok(Self(Box::new(CachedBtfSection::new(reader, base)?)))
     }
 
-    /// Find a list of BTF ids using their name as a key.
+    /// Find a list of BTF ids with a given name.
     ///
-    /// Using an empty name (`""`) resolves anonymous types (for BTF kinds
-    /// allowing it).
+    /// Using an empty name (`""`) resolves anonymous ids.
     pub fn resolve_ids_by_name(&self, name: &str) -> Result<Vec<u32>> {
         self.0.resolve_ids_by_name(name)
     }
 
     /// Find a list of BTF ids whose names match a regex.
     ///
-    /// Using an empty name (`""`) resolves anonymous types (for BTF kinds
-    /// allowing it).
+    /// If the regex matches the empty name (`""`), e.g. `"^$"`, the result will
+    /// contain anonymous ids.
     #[cfg(feature = "regex")]
     pub fn resolve_ids_by_regex(&self, re: &regex::Regex) -> Result<Vec<u32>> {
         self.0.resolve_ids_by_regex(re)
     }
 
-    /// Find a BTF type using its id as a key.
+    /// Find a BTF type with a given id.
     pub fn resolve_type_by_id(&self, id: u32) -> Result<Type> {
         self.0.resolve_type_by_id(id)
     }
 
-    /// Find a list of BTF types using their name as a key.
+    /// Find a list of BTF types with a given name.
     ///
-    /// Using an empty name (`""`) resolves anonymous types (for BTF kinds
-    /// allowing it).
+    /// Using an empty name (`""`) resolves anonymous types.
     pub fn resolve_types_by_name(&self, name: &str) -> Result<Vec<Type>> {
         let mut types = Vec::new();
         self.resolve_ids_by_name(name)?
@@ -68,10 +66,10 @@ impl BtfSection {
         Ok(types)
     }
 
-    /// Find a list of BTF types using a regex describing their name as a key.
+    /// Find a list of BTF types whose names match a regex.
     ///
-    /// Using an empty name (`""`) resolves anonymous types (for BTF kinds
-    /// allowing it).
+    /// If the regex matches the empty name (`""`), e.g. `"^$"`, the result will
+    /// contain anonymous types.
     #[cfg(feature = "regex")]
     pub fn resolve_types_by_regex(&self, re: &regex::Regex) -> Result<Vec<Type>> {
         let mut types = Vec::new();
@@ -131,9 +129,9 @@ pub(super) trait BtfBackend {
     fn type_id_offset(&self) -> u32;
     // Return the number of types in the section.
     fn types(&self) -> usize;
-    // Find a list of BTF ids using their name as a key.
+    // Find a list of BTF ids with a given name.
     fn resolve_ids_by_name(&self, name: &str) -> Result<Vec<u32>>;
-    // Find a BTF type using its id as a key.
+    // Find a BTF type with a given id.
     fn resolve_type_by_id(&self, id: u32) -> Result<Type>;
     // Resolve a name using its offset.
     fn resolve_name_by_offset(&self, offset: u32) -> Option<String>;

--- a/btf-rs/src/utils/collection.rs
+++ b/btf-rs/src/utils/collection.rs
@@ -202,12 +202,13 @@ impl BtfCollection {
             .map(|i| (&self.base, i))
             .collect::<Vec<_>>();
 
-        for split in self.split.iter() {
-            split
-                .btf
-                .resolve_split_ids_by_name(name)?
-                .drain(..)
-                .for_each(|i| ids.push((split, i)));
+        for btf in self.split.iter() {
+            if let Some(split) = btf.split() {
+                split
+                    .resolve_ids_by_name(name)?
+                    .drain(..)
+                    .for_each(|i| ids.push((btf, i)));
+            }
         }
 
         Ok(ids)
@@ -230,12 +231,13 @@ impl BtfCollection {
             .map(|i| (&self.base, i))
             .collect::<Vec<_>>();
 
-        for split in self.split.iter() {
-            split
-                .btf
-                .resolve_split_ids_by_regex(re)?
-                .drain(..)
-                .for_each(|i| ids.push((split, i)));
+        for btf in self.split.iter() {
+            if let Some(split) = btf.split() {
+                split
+                    .resolve_ids_by_regex(re)?
+                    .drain(..)
+                    .for_each(|i| ids.push((btf, i)));
+            }
         }
 
         Ok(ids)
@@ -255,12 +257,13 @@ impl BtfCollection {
             .map(|t| (&self.base, t))
             .collect::<Vec<_>>();
 
-        for split in self.split.iter() {
-            split
-                .btf
-                .resolve_split_types_by_name(name)?
-                .drain(..)
-                .for_each(|t| types.push((split, t)));
+        for btf in self.split.iter() {
+            if let Some(split) = btf.split() {
+                split
+                    .resolve_types_by_name(name)?
+                    .drain(..)
+                    .for_each(|t| types.push((btf, t)));
+            }
         }
 
         Ok(types)
@@ -282,12 +285,13 @@ impl BtfCollection {
             .map(|t| (&self.base, t))
             .collect::<Vec<_>>();
 
-        for split in self.split.iter() {
-            split
-                .btf
-                .resolve_split_types_by_regex(re)?
-                .drain(..)
-                .for_each(|t| types.push((split, t)));
+        for btf in self.split.iter() {
+            if let Some(split) = btf.split() {
+                split
+                    .resolve_types_by_regex(re)?
+                    .drain(..)
+                    .for_each(|t| types.push((btf, t)));
+            }
         }
 
         Ok(types)

--- a/btf-rs/src/utils/collection.rs
+++ b/btf-rs/src/utils/collection.rs
@@ -188,11 +188,13 @@ impl BtfCollection {
         self.split.iter().find(|m| m.name == name)
     }
 
-    /// Find a list of BTF ids using their name as a key. Matching ids can be
-    /// found in multiple underlying BTF, thus this function returns a list of
-    /// tuples containing each a reference to [`NamedBtf`] (representing the BTF
-    /// where a match was found) and the id. Further lookups must be done using
-    /// the [`Btf`] object contained in the linked [`NamedBtf`] one.
+    /// Find a list of BTF ids with a given name.
+    ///
+    /// Matching ids can be found in multiple underlying BTF, thus this function
+    /// returns a list of tuples containing each a reference to [`NamedBtf`]
+    /// (representing the BTF where a match was found) and the id. Further
+    /// lookups must be done using the [`Btf`] object contained in the linked
+    /// [`NamedBtf`] one.
     pub fn resolve_ids_by_name(&self, name: &str) -> Result<Vec<(&NamedBtf, u32)>> {
         let mut ids = self
             .base
@@ -243,11 +245,13 @@ impl BtfCollection {
         Ok(ids)
     }
 
-    /// Find a list of BTF types using their name as a key. Matching types can
-    /// be found in multiple underlying BTF, thus this function returns a list
-    /// of tuples containing each a reference to [`NamedBtf`] (representing the
-    /// BTF where a match was found) and the type. Further lookups must be done
-    /// using the [`Btf`] object contained in the linked [`NamedBtf`] one.
+    /// Find a list of BTF types with a given name.
+    ///
+    /// Matching types can be found in multiple underlying BTF, thus this
+    /// function returns a list of tuples containing each a reference to
+    /// [`NamedBtf`] (representing the BTF where a match was found) and the
+    /// type. Further lookups must be done using the [`Btf`] object contained in
+    /// the linked [`NamedBtf`] one.
     pub fn resolve_types_by_name(&self, name: &str) -> Result<Vec<(&NamedBtf, Type)>> {
         let mut types = self
             .base
@@ -269,7 +273,8 @@ impl BtfCollection {
         Ok(types)
     }
 
-    /// Find a list of BTF types using a regex describing their name as a key.
+    /// Find a list of BTF types whose names match a regex.
+    ///
     /// Matching types can be found in multiple underlying BTF, thus this
     /// function returns a list of tuples containing each a reference to
     /// [`NamedBtf`] (representing the BTF where a match was found) and the

--- a/btf-rs/tests/integration_test.rs
+++ b/btf-rs/tests/integration_test.rs
@@ -98,11 +98,24 @@ fn split_compressed_elf(alg: &str, ext: &str) -> Btf {
     .expect("split Btf construction failed")
 }
 
+#[test_case(bytes())]
+#[test_case(file())]
+#[test_case(file_cache())]
+#[test_case(file_mmap())]
+fn base_btf(btf: Btf) {
+    assert!(btf.split().is_none());
+}
+
 #[test_case(split_file())]
 #[test_case(split_file_cache())]
 #[test_case(split_file_mmap())]
-fn double_split(btf: Btf) {
+#[test_case(split_bytes())]
+fn split_btf(btf: Btf) {
+    // Ensure a split BTF cannot be constructed using another split BTF as the
+    // base.
     assert!(Btf::from_split_file("tests/assets/btf/openvswitch", &btf).is_err());
+
+    assert!(btf.split().is_some());
 }
 
 // TODO: use assert_matches! once stable.

--- a/btf-rs/tests/integration_test.rs
+++ b/btf-rs/tests/integration_test.rs
@@ -515,7 +515,7 @@ fn resolve_anon_regex(btf: Btf) {
     feature = "elf-compression",
     test_case(split_compressed_elf("zstd+zstd", "zst"))
 )]
-fn iter_types(btf: Btf) {
+fn chained_type_iter(btf: Btf) {
     // Iterate without looping ensuring non BtfTypes return None.
     let kfree = match btf
         .resolve_types_by_name("kfree")
@@ -527,7 +527,7 @@ fn iter_types(btf: Btf) {
         _ => panic!("Resolved type is not a function"),
     };
 
-    let mut iter = btf.type_iter(&kfree);
+    let mut iter = btf.chained_type_iter(&kfree);
     assert!(iter.next().is_some());
     assert!(iter.next().is_none());
 
@@ -548,7 +548,7 @@ fn iter_types(btf: Btf) {
         .find(|&m| btf.resolve_name(m).unwrap_or_default().eq("mac_len"));
 
     let types: Vec<Type> = btf
-        .type_iter(ml.unwrap())
+        .chained_type_iter(ml.unwrap())
         .filter(|t| matches!(t, Type::Typedef(_) | Type::Int(_)))
         .collect::<Vec<_>>();
 

--- a/btf-rs/tests/integration_test.rs
+++ b/btf-rs/tests/integration_test.rs
@@ -1,5 +1,6 @@
 use std::fs::read;
 
+use fallible_iterator::FallibleIterator;
 use test_case::test_case;
 
 use btf_rs::{utils::collection::*, *};
@@ -240,6 +241,15 @@ fn split_btf(btf: Btf) {
             Type::Enum(_)
         ));
     }
+
+    // type_iter()
+    let (_, base_max) = base.type_id_range();
+    let count = base.type_iter().count().unwrap();
+    assert_eq!(count, base_max as usize + 1);
+
+    let (split_min, split_max) = split.type_id_range();
+    let count = split.type_iter().count().unwrap();
+    assert_eq!(count, (split_max - split_min) as usize + 1);
 }
 
 // TODO: use assert_matches! once stable.
@@ -352,6 +362,14 @@ fn btf_api(btf: Btf) {
     let mut sk_buff = btf.resolve_types_by_name("sk_buff").unwrap();
     assert_eq!(sk_buff.len(), 1);
     assert!(matches!(sk_buff.pop().unwrap(), Type::Struct(_)));
+
+    // type_iter()
+    let (_, type_max) = match btf.split() {
+        Some(split) => split.type_id_range(),
+        None => btf.base().type_id_range(),
+    };
+    let count = btf.type_iter().count().unwrap();
+    assert_eq!(count, type_max as usize + 1);
 }
 
 #[test_case(bytes())]


### PR DESCRIPTION
As discussed in #31,

- Expose the underlying sections and offer a partial API.
- Allow to get a section type id range, which can be used to iter over types in a loop or compare the ids returned by the API.
- Allow to iterate over all types (`Type`) defined in either a full `Btf` representation or per-section.

The implementation of the last point needs to be finalized. It currently hides errors. One option would be to return `None` whenever an error is seen, but this hides potential problems (and e.g. how do the user know if the iteration failed early or completed?). Another option would be to return `Option<Result<Type>>` from the iterator but this is a lot more complex to consume[1]. Comments welcomed.

This is based on #33.

[1] This would make the API not perfectly fit to be consumed by `try_for_each()` and would be consumed in `for t in btf.iter_types() { ... }` (like `std::io::Lines`) and we go full circle with my initial proposal to just consume `type_id_range()`+`resolve_type_by_id()` and handle errors properly. This was fought in the other PR so if this is not an issue for you, I'm giving up on this aspect.